### PR TITLE
Add missing `prefixLength` to IP allocation

### DIFF
--- a/pkg/onmetal/create_machine.go
+++ b/pkg/onmetal/create_machine.go
@@ -144,6 +144,7 @@ func (d *onmetalDriver) applyOnMetalMachine(ctx context.Context, req *driver.Cre
 											Ephemeral: &networkingv1alpha1.EphemeralPrefixSource{
 												PrefixTemplate: &ipamv1alpha1.PrefixTemplateSpec{
 													Spec: ipamv1alpha1.PrefixSpec{
+														PrefixLength: 1,
 														ParentRef: &corev1.LocalObjectReference{
 															Name: providerSpec.PrefixName,
 														},

--- a/pkg/onmetal/create_machine_test.go
+++ b/pkg/onmetal/create_machine_test.go
@@ -93,7 +93,8 @@ var _ = Describe("CreateMachine", func() {
 										Ephemeral: &networkingv1alpha1.EphemeralPrefixSource{
 											PrefixTemplate: &ipamv1alpha1.PrefixTemplateSpec{
 												Spec: ipamv1alpha1.PrefixSpec{
-													IPFamily: corev1.IPv4Protocol,
+													IPFamily:     corev1.IPv4Protocol,
+													PrefixLength: 1,
 													ParentRef: &corev1.LocalObjectReference{
 														Name: "my-prefix",
 													},


### PR DESCRIPTION
# Proposed Changes

Add missing `prefixLength` to IP allocation.