### PR TITLE
Fix `NetworkInterface` `Prefix` allocation

### DIFF
--- a/pkg/onmetal/create_machine.go
+++ b/pkg/onmetal/create_machine.go
@@ -144,7 +144,8 @@ func (d *onmetalDriver) applyOnMetalMachine(ctx context.Context, req *driver.Cre
 											Ephemeral: &networkingv1alpha1.EphemeralPrefixSource{
 												PrefixTemplate: &ipamv1alpha1.PrefixTemplateSpec{
 													Spec: ipamv1alpha1.PrefixSpec{
-														PrefixLength: 1,
+														// request single IP
+														PrefixLength: 32,
 														ParentRef: &corev1.LocalObjectReference{
 															Name: providerSpec.PrefixName,
 														},

--- a/pkg/onmetal/create_machine_test.go
+++ b/pkg/onmetal/create_machine_test.go
@@ -94,7 +94,7 @@ var _ = Describe("CreateMachine", func() {
 											PrefixTemplate: &ipamv1alpha1.PrefixTemplateSpec{
 												Spec: ipamv1alpha1.PrefixSpec{
 													IPFamily:     corev1.IPv4Protocol,
-													PrefixLength: 1,
+													PrefixLength: 32,
 													ParentRef: &corev1.LocalObjectReference{
 														Name: "my-prefix",
 													},


### PR DESCRIPTION
# Proposed Changes

As there is currently a bug in the `onmetal-api` with the defaulting of a single IP allocation we need to explicitly set the `prefixLength`.

/ref https://github.com/onmetal/onmetal-api/issues/647