### PR TITLE
Remove forked dependency to MCM

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/coreos/butane v0.17.0
 	github.com/gardener/gardener v1.66.0
-	github.com/gardener/machine-controller-manager v0.48.1
+	github.com/gardener/machine-controller-manager v0.48.1-0.20230316071156-a00b3a8fb489
 	github.com/google/addlicense v1.1.1
 	github.com/imdario/mergo v0.3.14
 	github.com/onmetal/controller-utils v0.7.0
@@ -26,10 +26,7 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
-replace (
-	github.com/gardener/machine-controller-manager => github.com/afritzler/machine-controller-manager v0.0.0-20230305121828-d4df935993dc
-	k8s.io/client-go => k8s.io/client-go v0.26.2
-)
+replace k8s.io/client-go => k8s.io/client-go v0.26.2
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,6 @@ github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3Q
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZCSYp4Z0m2dk6cEM60=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
-github.com/afritzler/machine-controller-manager v0.0.0-20230305121828-d4df935993dc h1:mAroUA6wUbSyfzQ5x2fkvF6hCCKfXyhqwn3/jcSD63s=
-github.com/afritzler/machine-controller-manager v0.0.0-20230305121828-d4df935993dc/go.mod h1:D27CKAhtSE7JgHIBrLyYsgVEK5z4mPl/JJZRU/DYf9w=
 github.com/aws/aws-sdk-go v1.30.28/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.34.0 h1:brux2dRrlwCF5JhTL7MUT3WUwo9zfDHZZp3+g3Mvlmo=
 github.com/aws/aws-sdk-go v1.34.0/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
@@ -98,6 +96,8 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gardener/gardener v1.66.0 h1:krDrGx6asbjLBJGI7MtAHTV5NtRk9K3LJy1/4zQS0uU=
 github.com/gardener/gardener v1.66.0/go.mod h1:nS3b9qWHphOkzK3aZZYHSlwKz2qTxcKSQ35iHnk80UY=
+github.com/gardener/machine-controller-manager v0.48.1-0.20230316071156-a00b3a8fb489 h1:KX1tMr80O75LlhNy9juApWFCKgEjIPOSlK96dQ/UblI=
+github.com/gardener/machine-controller-manager v0.48.1-0.20230316071156-a00b3a8fb489/go.mod h1:D27CKAhtSE7JgHIBrLyYsgVEK5z4mPl/JJZRU/DYf9w=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=


### PR DESCRIPTION
# Proposed Changes

Use upstream Machine Controller Manager dependency as it now supports the v1.26.0 k8s.io/* deps.

Fixes #65 