### PR TITLE
Refactor tests and use `SpecContext`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ vet: ## Run go vet against code.
 .PHONY: test
 test: fmt vet envtest check-license ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+	go mod tidy
 
 .PHONY: add-license
 add-license: addlicense ## Add license headers to all go files.

--- a/pkg/onmetal/create_machine_test.go
+++ b/pkg/onmetal/create_machine_test.go
@@ -28,7 +28,6 @@ import (
 	ipamv1alpha1 "github.com/onmetal/onmetal-api/api/ipam/v1alpha1"
 	networkingv1alpha1 "github.com/onmetal/onmetal-api/api/networking/v1alpha1"
 	storagev1alpha1 "github.com/onmetal/onmetal-api/api/storage/v1alpha1"
-	testutils "github.com/onmetal/onmetal-api/utils/testing"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -39,10 +38,9 @@ import (
 )
 
 var _ = Describe("CreateMachine", func() {
-	ctx := testutils.SetupContext()
-	ns, providerSecret, drv := SetupTest(ctx)
+	ns, providerSecret, drv := SetupTest()
 
-	It("should create a machine", func() {
+	It("should create a machine", func(ctx SpecContext) {
 		By("creating machine")
 		machineName := "machine-0"
 		Expect((*drv).CreateMachine(ctx, &driver.CreateMachineRequest{

--- a/pkg/onmetal/delete_machine_test.go
+++ b/pkg/onmetal/delete_machine_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/onmetal/machine-controller-manager-provider-onmetal/pkg/api/v1alpha1"
 	"github.com/onmetal/machine-controller-manager-provider-onmetal/pkg/onmetal/testing"
 	computev1alpha1 "github.com/onmetal/onmetal-api/api/compute/v1alpha1"
-	testutils "github.com/onmetal/onmetal-api/utils/testing"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -31,10 +30,9 @@ import (
 )
 
 var _ = Describe("DeleteMachine", func() {
-	ctx := testutils.SetupContext()
-	ns, providerSecret, drv := SetupTest(ctx)
+	ns, providerSecret, drv := SetupTest()
 
-	It("should create and delete a machine", func() {
+	It("should create and delete a machine", func(ctx SpecContext) {
 		By("creating an onmetal machine")
 		Expect((*drv).CreateMachine(ctx, &driver.CreateMachineRequest{
 			Machine:      newMachine(ns, "machine", -1, nil),

--- a/pkg/onmetal/get_machine_status_test.go
+++ b/pkg/onmetal/get_machine_status_test.go
@@ -22,16 +22,14 @@ import (
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/status"
 	"github.com/onmetal/machine-controller-manager-provider-onmetal/pkg/api/v1alpha1"
 	"github.com/onmetal/machine-controller-manager-provider-onmetal/pkg/onmetal/testing"
-	testutils "github.com/onmetal/onmetal-api/utils/testing"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("GetMachineStatus", func() {
-	ctx := testutils.SetupContext()
-	ns, providerSecret, drv := SetupTest(ctx)
+	ns, providerSecret, drv := SetupTest()
 
-	It("should create a machine and ensure status", func() {
+	It("should create a machine and ensure status", func(ctx SpecContext) {
 		By("check empty request")
 		emptyMacReq := &driver.GetMachineStatusRequest{
 			Machine:      nil,

--- a/pkg/onmetal/get_volume_ids_test.go
+++ b/pkg/onmetal/get_volume_ids_test.go
@@ -15,16 +15,15 @@ package onmetal
 
 import (
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
-	testutils "github.com/onmetal/onmetal-api/utils/testing"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 )
 
 var _ = Describe("GetVolumeIDs", func() {
-	ctx := testutils.SetupContext()
-	_, _, drv := SetupTest(ctx)
-	It("should get volume IDs", func() {
+	_, _, drv := SetupTest()
+
+	It("should get volume IDs", func(ctx SpecContext) {
 		By("giving correct driver name")
 		csiDriverName := OnmetalCSIDriver
 		volumeIDs := []string{"vol-onmetal-csi"}

--- a/pkg/onmetal/list_machines_test.go
+++ b/pkg/onmetal/list_machines_test.go
@@ -20,16 +20,14 @@ import (
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
 	"github.com/onmetal/machine-controller-manager-provider-onmetal/pkg/api/v1alpha1"
 	"github.com/onmetal/machine-controller-manager-provider-onmetal/pkg/onmetal/testing"
-	testutils "github.com/onmetal/onmetal-api/utils/testing"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("ListMachines", func() {
-	ctx := testutils.SetupContext()
-	ns, providerSecret, drv := SetupTest(ctx)
+	ns, providerSecret, drv := SetupTest()
 
-	It("should fail if no provider has been set", func() {
+	It("should fail if no provider has been set", func(ctx SpecContext) {
 		By("ensuring an error if no provider has been set")
 		_, err := (*drv).ListMachines(ctx, &driver.ListMachinesRequest{
 			MachineClass: newMachineClass("", testing.SampleProviderSpec),
@@ -38,7 +36,7 @@ var _ = Describe("ListMachines", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
-	It("should list no machines if none have been created", func() {
+	It("should list no machines if none have been created", func(ctx SpecContext) {
 		By("ensuring the list response contains no machines")
 		listMachineResponse, err := (*drv).ListMachines(ctx, &driver.ListMachinesRequest{
 			MachineClass: newMachineClass(v1alpha1.ProviderName, testing.SampleProviderSpec),
@@ -48,7 +46,7 @@ var _ = Describe("ListMachines", func() {
 		Expect(listMachineResponse.MachineList).To(Equal(map[string]string{}))
 	})
 
-	It("should list a single machine if one has been created", func() {
+	It("should list a single machine if one has been created", func(ctx SpecContext) {
 		By("creating a machine")
 		craeteMachineResponse, err := (*drv).CreateMachine(ctx, &driver.CreateMachineRequest{
 			Machine:      newMachine(ns, "machine", -1, nil),
@@ -72,14 +70,14 @@ var _ = Describe("ListMachines", func() {
 		))
 
 		By("ensuring the cleanup of the machine")
-		DeferCleanup((*drv).DeleteMachine, ctx, &driver.DeleteMachineRequest{
+		DeferCleanup((*drv).DeleteMachine, &driver.DeleteMachineRequest{
 			Machine:      newMachine(ns, "machine", -1, nil),
 			MachineClass: newMachineClass(v1alpha1.ProviderName, testing.SampleProviderSpec),
 			Secret:       providerSecret,
 		})
 	})
 
-	It("should list two machines if two have been created", func() {
+	It("should list two machines if two have been created", func(ctx SpecContext) {
 		By("creating the first machine")
 		craeteMachineResponse, err := (*drv).CreateMachine(ctx, &driver.CreateMachineRequest{
 			Machine:      newMachine(ns, "machine", 0, nil),
@@ -116,14 +114,14 @@ var _ = Describe("ListMachines", func() {
 		}))
 
 		By("ensuring the cleanup of the first machine")
-		DeferCleanup((*drv).DeleteMachine, ctx, &driver.DeleteMachineRequest{
+		DeferCleanup((*drv).DeleteMachine, &driver.DeleteMachineRequest{
 			Machine:      newMachine(ns, "machine", 0, nil),
 			MachineClass: newMachineClass(v1alpha1.ProviderName, testing.SampleProviderSpec),
 			Secret:       providerSecret,
 		})
 
 		By("ensuring the cleanup of the second machine")
-		DeferCleanup((*drv).DeleteMachine, ctx, &driver.DeleteMachineRequest{
+		DeferCleanup((*drv).DeleteMachine, &driver.DeleteMachineRequest{
 			Machine:      newMachine(ns, "machine", 1, nil),
 			MachineClass: newMachineClass(v1alpha1.ProviderName, testing.SampleProviderSpec),
 			Secret:       providerSecret,


### PR DESCRIPTION
# Proposed Changes

- Use `SpecContext` instead of global context in suite tests
